### PR TITLE
[quickesn] Spack exercise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,36 @@
 cmake_minimum_required(VERSION "3.12")
-
 project("spackexample" VERSION 0.3.0)
 
-find_package(Boost
-  1.65.1
-  REQUIRED
-  filesystem
-  )
+option(WITH_BOOST "Enable Boost" ON)
+option(WITH_YAML "Enable yaml-cpp" ON)
 
-find_package(yaml-cpp
-  0.7.0
-  REQUIRED
-  )
+if(WITH_BOOST)
+  find_package(Boost 1.65.1 REQUIRED filesystem)
+endif()
 
-add_library(spackexamplelib filesystem/filesystem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+if(WITH_YAML)
+  find_package(yaml-cpp 0.7.0 REQUIRED)
+endif()
+
+set(SOURCES
+    filesystem/filesystem.cpp
+    flatset/flatset.cpp
+)
+
+if(WITH_YAML)
+    list(APPEND SOURCES yamlParser/yamlParser.cpp)
+endif()
+
+add_library(spackexamplelib ${SOURCES})
 
 set_target_properties(spackexamplelib
   PROPERTIES
     PUBLIC_HEADER filesystem/filesystem.hpp
     PUBLIC_HEADER flatset/flatset.hpp
-    PUBLIC_HEADER yamlParser/yamlParser.hpp
-  )
-
-include_directories(${YAML_CPP_INCLUDE_DIR})
+)
 
 add_executable(spackexample main.cpp)
-
 target_link_libraries(spackexample spackexamplelib)
-target_link_libraries(spackexamplelib Boost::filesystem yaml-cpp)
 
 target_include_directories(spackexamplelib
     PRIVATE
@@ -35,9 +38,17 @@ target_include_directories(spackexamplelib
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/spackexamplelib>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/spackexamplelib>
-  )
+)
 
-# Create install targets
+if(WITH_BOOST)
+    target_link_libraries(spackexamplelib Boost::filesystem)
+endif()
+
+if(WITH_YAML)
+    target_include_directories(spackexamplelib PUBLIC ${YAML_CPP_INCLUDE_DIR})
+    target_link_libraries(spackexamplelib yaml-cpp)
+endif()
+
 include(GNUInstallDirs)
 install(TARGETS spackexample spackexamplelib
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -45,4 +56,4 @@ install(TARGETS spackexample spackexamplelib
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spackexample
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spackexample
-  )
+)

--- a/docker/package.py
+++ b/docker/package.py
@@ -1,0 +1,44 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install spack-exercise
+#
+# You can edit this file again by typing:
+#
+#     spack edit spack-exercise
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class SpackExercise(CMakePackage):
+    """Today we get in touch with spack. Creating our first project and get in touch with Docker, CMake and other dependencies. """
+    homepage = "https://simulation-software-engineering.github.io/homepage/"
+    url = "https://github.com/Simulation-Software-Engineering/spack-exercise/archive/refs/tags/v0.3.0.tar.gz"
+    git = "https://github.com/Simulation-Software-Engineering/spack-exercise.git"
+    maintainers("svquick")
+
+    license("MIT", checked_by="svquick")
+
+    version("main", branch="main", get_full_repo=True)
+    version("0.3.0", sha256="c179ccc9d56b724fcb7eeff8cebbc1afe2797929b99aa6e7d9b8478a014f2d02")
+    version("0.2.0", sha256="010c900a3d4770116844636b89c1e42b1920f27c3da615543fb14f2ae9bb7f64")
+    version("0.1.0", sha256="f1c212a58376fd78e9854576627e6927d7cb93ccffe3a162b1664570c491e3a7")
+
+    depends_on("c", type="build")
+    depends_on("cxx",type="build")
+    depends_on("boost", when="@0.2.0:")
+    depends_on("yaml-cpp", when="@0.3.0:")

--- a/docker/package_optional-task2.py
+++ b/docker/package_optional-task2.py
@@ -1,0 +1,47 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install spack-exercise
+#
+# You can edit this file again by typing:
+#
+#     spack edit spack-exercise
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class SpackExercise(CMakePackage):
+    """Today we get in touch with spack. Creating our first project and get in touch with Docker, CMake and other dependencies. """
+    homepage = "https://simulation-software-engineering.github.io/homepage/"
+    url = "https://github.com/Simulation-Software-Engineering/spack-exercise/archive/refs/tags/v0.3.0.tar.gz"
+    git = "https://github.com/Simulation-Software-Engineering/spack-exercise.git"
+    maintainers("svquick")
+
+    license("MIT", checked_by="svquick")
+
+    version("main", branch="main", get_full_repo=True)
+    version("0.3.0", sha256="c179ccc9d56b724fcb7eeff8cebbc1afe2797929b99aa6e7d9b8478a014f2d02")
+    version("0.2.0", sha256="010c900a3d4770116844636b89c1e42b1920f27c3da615543fb14f2ae9bb7f64")
+    version("0.1.0", sha256="f1c212a58376fd78e9854576627e6927d7cb93ccffe3a162b1664570c491e3a7")
+
+    depends_on("c", type="build")
+    depends_on("cxx",type="build")
+
+    variant("boost", default=True, description="Enable Boost")
+    variant("yaml", default=True, description="Enable yaml-cpp")
+    depends_on("boost", when="+boost")
+    depends_on("yaml-cpp", when="+yaml")


### PR DESCRIPTION
I included a working package.py for the first optional task.
`spack install spack-exercise@main` adding the main branch works.

Unfortunately, I couldn't get any further with the second optional task. I get a CMake error; it seems that the CMakeList from the Git repo is always used and my customized CMakeList.txt, which contains the optional yaml-cpp and Boost, is not used.
The modified CMakeList.txt and package_optional-task2.py are also included in the PR.