### PR TITLE
[rehmanal] Spack exercise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,47 +2,60 @@ cmake_minimum_required(VERSION "3.12")
 
 project("spackexample" VERSION 0.3.0)
 
-find_package(Boost
-  1.65.1
-  REQUIRED
-  filesystem
-  )
+# Define options for dependencies
+option(USE_BOOST "Use Boost libraries" ON)
+option(USE_YAML "Use yaml-cpp libraries" ON)
 
-find_package(yaml-cpp
-  0.7.0
-  REQUIRED
-  )
+set(SRCS "")
+set(LIBS "")
+set(HDRS "")
 
-add_library(spackexamplelib filesystem/filesystem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
+# Handle Boost
+if(USE_BOOST)
+  find_package(Boost 1.65.1 REQUIRED filesystem)
+  list(APPEND SRCS filesystem/filesystem.cpp flatset/flatset.cpp)
+  list(APPEND HDRS filesystem/filesystem.hpp flatset/flatset.hpp)
+  list(APPEND LIBS Boost::filesystem)
+  add_compile_definitions(USE_BOOST)
+endif()
 
-set_target_properties(spackexamplelib
-  PROPERTIES
-    PUBLIC_HEADER filesystem/filesystem.hpp
-    PUBLIC_HEADER flatset/flatset.hpp
-    PUBLIC_HEADER yamlParser/yamlParser.hpp
-  )
+# Handle yaml-cpp
+if(USE_YAML)
+  find_package(yaml-cpp 0.7.0 REQUIRED)
+  list(APPEND SRCS yamlParser/yamlParser.cpp)
+  list(APPEND HDRS yamlParser/yamlParser.hpp)
+  list(APPEND LIBS yaml-cpp)
+  add_compile_definitions(USE_YAML)
+endif()
 
-include_directories(${YAML_CPP_INCLUDE_DIR})
-
+# Create the executable
 add_executable(spackexample main.cpp)
 
-target_link_libraries(spackexample spackexamplelib)
-target_link_libraries(spackexamplelib Boost::filesystem yaml-cpp)
-
-target_include_directories(spackexamplelib
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/spackexamplelib
+# Only create the library if we have sources (dependencies are enabled)
+if(SRCS)
+  add_library(spackexamplelib ${SRCS})
+  target_link_libraries(spackexamplelib ${LIBS})
+  
+  # Include directories
+  target_include_directories(spackexamplelib
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/spackexamplelib
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/spackexamplelib>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/spackexamplelib>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/spackexamplelib>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/spackexamplelib>
   )
+  
+  # Link the executable to the library
+  target_link_libraries(spackexample spackexamplelib)
+  
+  # Installation instructions for the library
+  include(GNUInstallDirs)
+  install(TARGETS spackexamplelib
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spackexample
+  )
+endif()
 
-# Create install targets
+# Installation instructions for the executable
 include(GNUInstallDirs)
-install(TARGETS spackexample spackexamplelib
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spackexample
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spackexample
-  )
+install(TARGETS spackexample RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/main.cpp
+++ b/main.cpp
@@ -1,12 +1,19 @@
-#include "flatset/flatset.hpp"
-#include "filesystem/filesystem.hpp"
-#include "yamlParser/yamlParser.hpp"
 #include <iostream>
+
+#ifdef USE_BOOST
+  #include "flatset/flatset.hpp"
+  #include "filesystem/filesystem.hpp"
+#endif
+
+#ifdef USE_YAML
+  #include "yamlParser/yamlParser.hpp"
+#endif
 
 int main(int argc, char *argv[])
 {
   std::cout << "Let's fight with CMake, Docker, and some dependencies!" << std::endl << std::endl;
 
+#ifdef USE_BOOST
   std::cout << "Modify a flat set using boost container" << std::endl;
   modifyAndPrintSets();
   std::cout << std::endl;
@@ -14,7 +21,11 @@ int main(int argc, char *argv[])
   std::cout << "Inspect the current directory using boost filesystem" << std::endl;
   inspectDirectory();
   std::cout << std::endl;
+#else
+  std::cout << "Boost is disabled." << std::endl;
+#endif
 
+#ifdef USE_YAML
   if ( argc == 2 )
   {
     const std::string yamlFile( argv[1] );
@@ -22,7 +33,9 @@ int main(int argc, char *argv[])
     std::cout << "  " << yamlFile << std::endl;
     parseConfig( yamlFile );
   }
+#else
+  std::cout << "YAML-CPP is disabled." << std::endl;
+#endif
 
   return 0;
 }
-

--- a/package.py
+++ b/package.py
@@ -1,0 +1,44 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack.package import *
+
+class SpackExercise(CMakePackage):
+    """A simple example package for the Spack exercise."""
+
+    homepage = "https://simulation-software-engineering.github.io/homepage/"
+    url = "https://github.com/Simulation-Software-Engineering/spack-exercise/archive/refs/tags/v0.1.0.tar.gz"
+    
+    # Official repository URL for the main branch
+    git = "https://github.com/Simulation-Software-Engineering/spack-exercise.git"
+
+    maintainers("AbdulRehman-Fayyaz")
+
+    version("main", branch="main")
+    version("0.3.0", sha256="c179ccc9d56b724fcb7eeff8cebbc1afe2797929b99aa6e7d9b8478a014f2d02")
+    version("0.2.0", sha256="010c900a3d4770116844636b89c1e42b1920f27c3da615543fb14f2ae9bb7f64")
+    version("0.1.0", sha256="f1c212a58376fd78e9854576627e6927d7cb93ccffe3a162b1664570c491e3a7")
+
+    # Variants for optional dependencies
+    variant('boost', default=True, description='Enable Boost support')
+    variant('yaml', default=True, description='Enable YAML-CPP support')
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    # Conditional dependencies based on variants
+    depends_on("boost@1.65.1:", when="+boost")
+    depends_on("yaml-cpp@0.7.0:", when="+yaml")
+
+    # Old versions strictly require Boost/YAML, so we forbid disabling them there
+    conflicts("~boost", when="@0.2.0:0.3.0")
+    conflicts("~yaml", when="@0.3.0")
+
+    def cmake_args(self):
+        args = []
+        # Pass flags to CMake based on variants
+        args.append(self.define_from_variant("USE_BOOST", "boost"))
+        args.append(self.define_from_variant("USE_YAML", "yaml"))
+        return args


### PR DESCRIPTION
This Pull Request adds the `package.py` recipe for the Spack exercise.

The package successfully builds and installs versions `v0.1.0`, `v0.2.0`, and `v0.3.0` with the correct dependency constraints (Boost and yaml-cpp).

**Optional Tasks**
I have implemented the following optional extensions:
* **Git Version:** Added the `main` branch as a version source (`version('main', branch='main')`).
* **Variants:** Modified `CMakeLists.txt` and `main.cpp` to allow Boost and `yaml-cpp` to be optional. Added Spack variants (`+boost`, `+yaml`) to the recipe to control these features dynamically.

All configurations have been verified and tested inside the provided Docker environment.