### PR TITLE
[tucciafo] Spack exercise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION "3.12")
 
-project("spackexample" VERSION 0.3.0)
+project("spackexample" VERSION 0.3.1)
 
 option(ENABLE_BOOST "Disable the Boost support of this package" ON)
 option(ENABLE_YAML_CPP "Disable the Boost support of this package" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,32 +2,46 @@ cmake_minimum_required(VERSION "3.12")
 
 project("spackexample" VERSION 0.3.0)
 
-find_package(Boost
-  1.65.1
-  REQUIRED
-  filesystem
+option(ENABLE_BOOST "Disable the Boost support of this package" ON)
+option(ENABLE_YAML_CPP "Disable the Boost support of this package" ON)
+
+add_library(spackexamplelib main.cpp)
+
+if(ENABLE_BOOST)
+  find_package(Boost
+    1.65.1
+    REQUIRED
+    filesystem
   )
+  target_sources(spackexamplelib PRIVATE filesystem/filesystem.cpp flatset/flatset.cpp)
 
-find_package(yaml-cpp
-  0.7.0
-  REQUIRED
-  )
-
-add_library(spackexamplelib filesystem/filesystem.cpp flatset/flatset.cpp yamlParser/yamlParser.cpp)
-
-set_target_properties(spackexamplelib
-  PROPERTIES
+  set_target_properties(spackexamplelib PROPERTIES
     PUBLIC_HEADER filesystem/filesystem.hpp
     PUBLIC_HEADER flatset/flatset.hpp
+  )
+  target_link_libraries(spackexamplelib Boost::filesystem)
+  add_compile_definitions(ENABLE_BOOST)
+endif()
+
+if(ENABLE_YAML_CPP)
+  find_package(yaml-cpp
+    0.7.0
+    REQUIRED
+  )
+  target_sources(spackexamplelib PRIVATE yamlParser/yamlParser.cpp)
+
+  set_target_properties(spackexamplelib PROPERTIES
     PUBLIC_HEADER yamlParser/yamlParser.hpp
   )
+  target_link_libraries(spackexamplelib yaml-cpp)
+  add_compile_definitions(ENABLE_YAML_CPP)
+endif()
 
 include_directories(${YAML_CPP_INCLUDE_DIR})
 
 add_executable(spackexample main.cpp)
 
 target_link_libraries(spackexample spackexamplelib)
-target_link_libraries(spackexamplelib Boost::filesystem yaml-cpp)
 
 target_include_directories(spackexamplelib
     PRIVATE
@@ -45,4 +59,4 @@ install(TARGETS spackexample spackexamplelib
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spackexample
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/spackexample
-  )
+)

--- a/main.cpp
+++ b/main.cpp
@@ -1,20 +1,27 @@
+#ifdef ENABLE_BOOST
 #include "flatset/flatset.hpp"
 #include "filesystem/filesystem.hpp"
+#endif
+#ifdef ENABLE_YAML
 #include "yamlParser/yamlParser.hpp"
+#endif
 #include <iostream>
 
 int main(int argc, char *argv[])
 {
   std::cout << "Let's fight with CMake, Docker, and some dependencies!" << std::endl << std::endl;
 
+  #ifdef ENABLE_BOOST
   std::cout << "Modify a flat set using boost container" << std::endl;
   modifyAndPrintSets();
   std::cout << std::endl;
-
+  
   std::cout << "Inspect the current directory using boost filesystem" << std::endl;
   inspectDirectory();
   std::cout << std::endl;
+  #endif
 
+  #ifdef ENABLE_YAML
   if ( argc == 2 )
   {
     const std::string yamlFile( argv[1] );
@@ -22,6 +29,7 @@ int main(int argc, char *argv[])
     std::cout << "  " << yamlFile << std::endl;
     parseConfig( yamlFile );
   }
+  #endif
 
   return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -2,7 +2,7 @@
 #include "flatset/flatset.hpp"
 #include "filesystem/filesystem.hpp"
 #endif
-#ifdef ENABLE_YAML
+#ifdef ENABLE_YAML_CPP
 #include "yamlParser/yamlParser.hpp"
 #endif
 #include <iostream>
@@ -21,7 +21,7 @@ int main(int argc, char *argv[])
   std::cout << std::endl;
   #endif
 
-  #ifdef ENABLE_YAML
+  #ifdef ENABLE_YAML_CPP
   if ( argc == 2 )
   {
     const std::string yamlFile( argv[1] );

--- a/mandatory-exercise/package.py
+++ b/mandatory-exercise/package.py
@@ -1,0 +1,30 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class SpackExercise(CMakePackage):
+    """This is an exercise package aiming at a better understanding of Spack, Docker, CMake and Dependencies"""
+
+    homepage = "https://simulation-software-engineering.github.io/homepage/"
+    url = "https://github.com/Simulation-Software-Engineering/spack-exercise/archive/refs/tags/v0.3.0.tar.gz"
+
+    maintainers("FabioTucciarone")
+    license("Creative Commons", checked_by="FabioTucciarone")
+
+    version("0.3.0", sha256="c179ccc9d56b724fcb7eeff8cebbc1afe2797929b99aa6e7d9b8478a014f2d02")
+    version("0.2.0", sha256="010c900a3d4770116844636b89c1e42b1920f27c3da615543fb14f2ae9bb7f64")
+    version("0.1.0", sha256="f1c212a58376fd78e9854576627e6927d7cb93ccffe3a162b1664570c491e3a7")
+
+    depends_on("cxx", type="build")
+    depends_on("c", type="build")
+
+    variant("boost", default=True, description="SpackExercise with Boost support")
+    depends_on("boost@1.65.1:", when="@0.2.0:")
+    
+    variant("yamlcpp", default=True, description="SpackExercise with yaml-cpp support")
+    depends_on("yaml-cpp@0.7.0:", when="@0.3.0:")

--- a/optional-exercise/package.py
+++ b/optional-exercise/package.py
@@ -1,0 +1,43 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class SpackExercise(CMakePackage):
+    """This is an exercise package aiming at a better understanding of Spack, Docker, CMake and Dependencies"""
+
+    homepage = "https://simulation-software-engineering.github.io/homepage/"
+    url = "https://github.com/Simulation-Software-Engineering/spack-exercise/archive/refs/tags/v0.3.0.tar.gz"
+    git = "https://github.com/FabioTucciarone/spack-exercise.git"
+
+    maintainers("FabioTucciarone")
+    license("Creative Commons", checked_by="FabioTucciarone")
+
+    version("0.3.0", sha256="c179ccc9d56b724fcb7eeff8cebbc1afe2797929b99aa6e7d9b8478a014f2d02")
+    version("0.2.0", sha256="010c900a3d4770116844636b89c1e42b1920f27c3da615543fb14f2ae9bb7f64")
+    version("0.1.0", sha256="f1c212a58376fd78e9854576627e6927d7cb93ccffe3a162b1664570c491e3a7")
+    version("0.3.1", sha256="b0e310eb2dc6fc80ebf79e659db9c699c56ec9fa7bba1e0b98a2d2915b5e7d00")
+    version("main", branch="main")
+
+    depends_on("cxx", type="build")
+    depends_on("c", type="build")
+
+    variant("boost", default=True, description="SpackExercise with Boost support")
+    depends_on("boost@1.65.1:", when="@0.2.0: +boost")
+    #depends_on("boost@1.65.1:", when="@optional: +boost")
+    depends_on("boost@1.65.1:", when="@main: +boost")
+
+    variant("yamlcpp", default=True, description="SpackExercise with yaml-cpp support")
+    depends_on("yaml-cpp@0.7.0:", when="@0.3.0: +yamlcpp")
+    depends_on("yaml-cpp@0.7.0:", when="@optional: +yamlcpp")
+    depends_on("yaml-cpp@0.7.0:", when="@main: +yamlcpp")
+
+    def cmake_args(self):
+        return [
+            self.define("ENABLE_BOOST", "ON" if self.spec.satisfies("+boost") else "OFF"),
+            self.define("ENABLE_YAML_CPP", "ON" if self.spec.satisfies("+yamlcpp") else "OFF"),
+        ]


### PR DESCRIPTION
This PR contains both the `package.py` of the mandatory exercises in `mandatory-exercise/package.py` and the first two optional exercises in `optional-exercise/package.py`,  `main.cpp` and `CMakeLists.txt`.

Example: Build the newly added version 0.3.1 without yaml-cpp:

```
spack install spack-exercise@0.3.1~yamlcpp
```