### PR TITLE
[reinvt] Spack excercise

### DIFF
--- a/package.py
+++ b/package.py
@@ -1,0 +1,25 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class SpackExercise(CMakePackage):
+
+    """Small example C++ project for Spack packaging exercise."""
+
+    homepage = "https://simulation-software-engineering.github.io/homepage/"
+    url = "https://github.com/Simulation-Software-Engineering/spack-exercise/archive/refs/tags/v0.1.0.tar.gz"
+    maintainers("vincentrein")
+    license("MIT", checked_by="vincentrein")
+
+    version("0.3.0", sha256="c179ccc9d56b724fcb7eeff8cebbc1afe2797929b99aa6e7d9b8478a014f2d02")
+    version("0.2.0", sha256="010c900a3d4770116844636b89c1e42b1920f27c3da615543fb14f2ae9bb7f64")
+    version("0.1.0", sha256="f1c212a58376fd78e9854576627e6927d7cb93ccffe3a162b1664570c491e3a7")
+
+    depends_on("cmake@3.10:", type="build")
+    depends_on("boost", when="@0.2.0:")
+    depends_on("yaml-cpp@0.7.0", when="@0.3.0:")


### PR DESCRIPTION
Spack Exercise Submission

Github: @vincentrein
GitLab: reinvt

Changes: Added package.py for spack-exercise with versions 0.1.0, 0.2.0, and 0.3.0.

Testing Instructions

To verify the package and dependencies inside the provided Docker container:
Activate Spack Environment:
```
. /home/spackbuilder/spack/share/spack/setup-env.sh
```
Install & Load Version 0.3.0:
```
spack install spack-exercise@0.3.0
spack load spack-exercise@0.3.0
```

Run Executable:
```
spackexample
```
In order to make the spack commands work in the shell, I had to use:
```
eval $(spack load --sh spack-exercise@0.3.0)
spackexample /home/spackbuilder/spack-exercise/yamlParser/config.yml
```