### PR TITLE
[wolljs] Spack exercise

### DIFF
--- a/package.py
+++ b/package.py
@@ -1,0 +1,29 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class SpackExercise(CMakePackage):
+    """This is a spack exercise with an examlpe repo, in the content of the course SSE."""
+
+    homepage = "https://simulation-software-engineering.github.io/homepage/"
+    git = "https://github.com/Simulation-Software-Engineering/spack-exercise.git"
+    url = "https://github.com/Simulation-Software-Engineering/spack-exercise/archive/refs/tags/v0.1.0.tar.gz"
+
+    maintainers("Jelitaw", "Jelitau")
+
+    license("MIT", checked_by="Jelitaw")
+
+    version("main", branch="main")
+    version("0.3.0", sha256="c179ccc9d56b724fcb7eeff8cebbc1afe2797929b99aa6e7d9b8478a014f2d02")
+    version("0.2.0", sha256="010c900a3d4770116844636b89c1e42b1920f27c3da615543fb14f2ae9bb7f64")
+    version("0.1.0", sha256="f1c212a58376fd78e9854576627e6927d7cb93ccffe3a162b1664570c491e3a7")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("boost@1.65.1:", when="@0.2.0:")
+    depends_on("yaml-cpp@0.7.0:", when="@0.3.0")


### PR DESCRIPTION
Contains the edited package.py file, with all changes needed for the mandatory tasks.

Furthermore, of the optional tasks, the main branch was added to the recipe as a version.

To use the file, you have to run from inside the container:
```
spack create https://github.com/Simulation-Software-Engineering/spack-exercise/releases/tag/v0.1.0
```

Then replace the generated package.py with the uploaded package.py.